### PR TITLE
Add state to address

### DIFF
--- a/src/main/java/com/constantcontact/components/contacts/Address.java
+++ b/src/main/java/com/constantcontact/components/contacts/Address.java
@@ -30,7 +30,9 @@ public class Address implements Serializable {
 	@JsonIgnore
 	private String addressType;
 	@JsonIgnore
-	private String stateCode;
+	private String state;
+  @JsonIgnore
+  private String stateCode;
 	@JsonIgnore
 	private String countryCode;
 	@JsonIgnore
@@ -152,6 +154,25 @@ public class Address implements Serializable {
 	public void setAddressType(String addressType) {
 		this.addressType = addressType;
 	}
+
+  /**
+   * Gets the state.
+   * 
+   * @return The state.
+   */
+  @JsonProperty("state")
+  public String getState() {
+    return state;
+  }
+    
+  /**
+   * Sets the state.
+   * 
+   * @param state The state.
+   */
+  public void setState(String state) {
+    this.state = state;
+  }
 
 	/**
 	 * Gets the state code.

--- a/src/main/java/com/constantcontact/components/contacts/Address.java
+++ b/src/main/java/com/constantcontact/components/contacts/Address.java
@@ -31,8 +31,8 @@ public class Address implements Serializable {
 	private String addressType;
 	@JsonIgnore
 	private String state;
-  @JsonIgnore
-  private String stateCode;
+	@JsonIgnore
+	private String stateCode;
 	@JsonIgnore
 	private String countryCode;
 	@JsonIgnore
@@ -155,24 +155,24 @@ public class Address implements Serializable {
 		this.addressType = addressType;
 	}
 
-  /**
-   * Gets the state.
-   * 
-   * @return The state.
-   */
-  @JsonProperty("state")
-  public String getState() {
-    return state;
-  }
-    
-  /**
-   * Sets the state.
-   * 
-   * @param state The state.
-   */
-  public void setState(String state) {
-    this.state = state;
-  }
+	/**
+	 * Gets the state.
+	 * 
+	 * @return The state.
+	 */
+	@JsonProperty("state")
+	public String getState() {
+	  return state;
+	}
+
+	/**
+	 * Sets the state.
+	 * 
+	 * @param state The state.
+	 */
+	public void setState(String state) {
+	  this.state = state;
+	}
 
 	/**
 	 * Gets the state code.
@@ -273,6 +273,8 @@ public class Address implements Serializable {
 		builder.append(city);
 		builder.append(", addressType=");
 		builder.append(addressType);
+		builder.append(", state=");
+		builder.append(state);
 		builder.append(", stateCode=");
 		builder.append(stateCode);
 		builder.append(", countryCode=");


### PR DESCRIPTION
The API doc linked below specifies a "state" field under Address. It's specified in response structure and in the example response JSON. The java-sdk did not deserialize this field because it was missing from the Address POJO. I've added it here.

[http://developer.constantcontact.com/docs/contacts-api/contacts-resource.html](http://developer.constantcontact.com/docs/contacts-api/contacts-resource.html)