### PR TITLE
Not able to access account library images

### DIFF
--- a/lib-rx/src/main/java/com/constantcontact/v2/LibraryService.java
+++ b/lib-rx/src/main/java/com/constantcontact/v2/LibraryService.java
@@ -117,12 +117,11 @@ public interface LibraryService {
     /**
      * Get a {@link Paged} collection of {@link File} from a specific {@link Folder}.
      *
-     * @param folderId The Folder ID
      * @param nextLink Value of the link found in the meta of the original call
      * @return an Observable that emits Paged Files
      */
-    @GET("v2/library/folders/{folderId}/files?{next}")
-    Observable<Paged<File>> getFilesByFolder(@Path("folderId") String folderId, @Path("next") String nextLink);
+    @GET
+    Observable<Paged<File>> getFilesByFolder(@Url String nextLink);
 
     /**
      * Get a specific {@link File}

--- a/lib-rx/src/main/java/com/constantcontact/v2/LibraryService.java
+++ b/lib-rx/src/main/java/com/constantcontact/v2/LibraryService.java
@@ -94,8 +94,8 @@ public interface LibraryService {
      * @param nextLink Value of the link found in the meta of the original call
      * @return an Observable that emits Paged Files
      */
-    @GET("v2/library/files?next={next}")
-    Observable<Paged<File>> getFiles(@Path("next") String nextLink);
+    @GET
+    Observable<Paged<File>> getFiles(@Url String nextLink);
 
     /**
      * Get a {@link Paged} collection of {@link File} from a specific {@link Folder}.
@@ -121,7 +121,7 @@ public interface LibraryService {
      * @param nextLink Value of the link found in the meta of the original call
      * @return an Observable that emits Paged Files
      */
-    @GET("v2/library/folders/{folderId}/files?next={next}")
+    @GET("v2/library/folders/{folderId}/files?{next}")
     Observable<Paged<File>> getFilesByFolder(@Path("folderId") String folderId, @Path("next") String nextLink);
 
     /**

--- a/lib/src/main/java/com/constantcontact/v2/LibraryService.java
+++ b/lib/src/main/java/com/constantcontact/v2/LibraryService.java
@@ -116,12 +116,11 @@ public interface LibraryService {
     /**
      * Get a {@link Paged} collection of {@link File} from a specific {@link Folder}.
      *
-     * @param folderId The Folder ID
      * @param nextLink Value of the link found in the meta of the original call
      * @return an Observable that emits Paged Files
      */
-    @GET("v2/library/folders/{folderId}/files?{next}")
-    Call<Paged<File>> getFilesByFolder(@Path("folderId") String folderId, @Path("next") String nextLink);
+    @GET
+    Call<Paged<File>> getFilesByFolder(@Url String nextLink);
 
     /**
      * Get a specific {@link File}

--- a/lib/src/main/java/com/constantcontact/v2/LibraryService.java
+++ b/lib/src/main/java/com/constantcontact/v2/LibraryService.java
@@ -35,8 +35,8 @@ public interface LibraryService {
      * @param nextLink Value of the link found in the meta of the original call
      * @return an Observable that emits Paged Folders
      */
-    @GET("v2/library/folders?next={next}")
-    Call<Paged<Folder>> getFolders(@Path("next") String nextLink);
+    @GET
+    Call<Paged<Folder>> getFolders(@Url String nextLink);
 
     /**
      * Create a new {@link Folder}
@@ -120,7 +120,7 @@ public interface LibraryService {
      * @param nextLink Value of the link found in the meta of the original call
      * @return an Observable that emits Paged Files
      */
-    @GET("v2/library/folders/{folderId}/files?next={next}")
+    @GET("v2/library/folders/{folderId}/files?{next}")
     Call<Paged<File>> getFilesByFolder(@Path("folderId") String folderId, @Path("next") String nextLink);
 
     /**


### PR DESCRIPTION
1. Problem Description:
    Query string must not have a replace block - next={next}

2. Solution Description:
    Update paged implementation for Library