### PR TITLE
Mob 5549 remove non ascii

### DIFF
--- a/components/src/main/java/com/constantcontact/v2/campaigns/Campaign.java
+++ b/components/src/main/java/com/constantcontact/v2/campaigns/Campaign.java
@@ -12,12 +12,15 @@
 
 package com.constantcontact.v2.campaigns;
 
+import com.constantcontact.v2.converter.jackson.RemoveNonAsciiStringSerializer;
 import com.constantcontact.v2.tracking.TrackingSummary;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -37,27 +40,34 @@ public class Campaign implements Serializable {
     protected Date _createdDate;
 
     @JsonProperty("email_content")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _emailContent;
 
     @JsonProperty("email_content_format")
     protected String _emailContentFormat;
 
     @JsonProperty("from_email")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _fromEmail;
 
     @JsonProperty("from_name")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _fromName;
 
     @JsonProperty("greeting_name")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _greetingName;
 
     @JsonProperty("greeting_salutations")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _greetingSalutations;
 
     @JsonProperty("greeting_string")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _greetingString;
 
     @JsonProperty("id")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _id;
 
     @JsonProperty("is_permission_reminder_enabled")
@@ -77,18 +87,22 @@ public class Campaign implements Serializable {
     protected Date _modifiedDate;
 
     @JsonProperty("name")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _name;
 
     @JsonProperty("next_run_date")
     protected Date _nextRunDate;
 
     @JsonProperty("permalink_url")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _permalinkUrl;
 
     @JsonProperty("permission_reminder_text")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _permissionReminderText;
 
     @JsonProperty("reply_to_email")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _replyToEmail;
 
     @JsonProperty("sent_to_contact_lists")
@@ -98,24 +112,29 @@ public class Campaign implements Serializable {
     protected CampaignStatus _status;
 
     @JsonProperty("style_sheet")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _styleSheet;
 
     @JsonProperty("subject")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _subject;
 
     @JsonProperty("template_type")
     protected String _templateType;
 
     @JsonProperty("text_content")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _textContent;
 
     @JsonProperty("tracking_summary")
     protected TrackingSummary _trackingSummary;
 
     @JsonProperty("view_as_web_page_link_text")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _viewAsWebPageLinkText;
 
     @JsonProperty("view_as_web_page_text")
+    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _viewAsWebPageText;
 
     /**

--- a/components/src/main/java/com/constantcontact/v2/campaigns/Campaign.java
+++ b/components/src/main/java/com/constantcontact/v2/campaigns/Campaign.java
@@ -40,7 +40,6 @@ public class Campaign implements Serializable {
     protected Date _createdDate;
 
     @JsonProperty("email_content")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _emailContent;
 
     @JsonProperty("email_content_format")
@@ -51,23 +50,18 @@ public class Campaign implements Serializable {
     protected String _fromEmail;
 
     @JsonProperty("from_name")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _fromName;
 
     @JsonProperty("greeting_name")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _greetingName;
 
     @JsonProperty("greeting_salutations")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _greetingSalutations;
 
     @JsonProperty("greeting_string")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _greetingString;
 
     @JsonProperty("id")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _id;
 
     @JsonProperty("is_permission_reminder_enabled")
@@ -94,11 +88,9 @@ public class Campaign implements Serializable {
     protected Date _nextRunDate;
 
     @JsonProperty("permalink_url")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _permalinkUrl;
 
     @JsonProperty("permission_reminder_text")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _permissionReminderText;
 
     @JsonProperty("reply_to_email")
@@ -112,7 +104,6 @@ public class Campaign implements Serializable {
     protected CampaignStatus _status;
 
     @JsonProperty("style_sheet")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _styleSheet;
 
     @JsonProperty("subject")
@@ -123,18 +114,15 @@ public class Campaign implements Serializable {
     protected String _templateType;
 
     @JsonProperty("text_content")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _textContent;
 
     @JsonProperty("tracking_summary")
     protected TrackingSummary _trackingSummary;
 
     @JsonProperty("view_as_web_page_link_text")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _viewAsWebPageLinkText;
 
     @JsonProperty("view_as_web_page_text")
-    @JsonSerialize(using = RemoveNonAsciiStringSerializer.class, as=String.class)
     protected String _viewAsWebPageText;
 
     /**

--- a/components/src/main/java/com/constantcontact/v2/converter/jackson/RemoveNonAsciiStringSerializer.java
+++ b/components/src/main/java/com/constantcontact/v2/converter/jackson/RemoveNonAsciiStringSerializer.java
@@ -28,6 +28,6 @@ public class RemoveNonAsciiStringSerializer extends JsonSerializer<String> {
             }
         }
         return buff.toString();
-
     }
+
 }

--- a/components/src/main/java/com/constantcontact/v2/converter/jackson/RemoveNonAsciiStringSerializer.java
+++ b/components/src/main/java/com/constantcontact/v2/converter/jackson/RemoveNonAsciiStringSerializer.java
@@ -1,0 +1,33 @@
+package com.constantcontact.v2.converter.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class RemoveNonAsciiStringSerializer extends JsonSerializer<String> {
+    @Override
+    public void serialize(String value, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider)
+        throws IOException, JsonProcessingException {
+        String allAscii = removeNonASCIIChar(value);
+        jsonGenerator.writeString(allAscii);
+    }
+
+    private String removeNonASCIIChar(String str) {
+
+        StringBuffer buff = new StringBuffer();
+        char chars[] = str.toCharArray();
+
+        for (int i = 0; i < chars.length; i++) {
+            if (0 < chars[i] && chars[i] < 127) {
+
+                buff.append(chars[i]);
+            }
+        }
+        return buff.toString();
+
+    }
+}

--- a/components/src/test/java/com/constantcontact/v2/converter/jackson/JacksonTest.java
+++ b/components/src/test/java/com/constantcontact/v2/converter/jackson/JacksonTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2018 Constant Contact, Inc. All Rights Reserved.
+ * Boston, MA 02451, USA
+ * Phone: (781) 472-8100
+ * Fax: (781) 472-8101
+ * This software is the confidential and proprietary information
+ * of Constant Contact, Inc. created for Constant Contact, Inc.
+ * You shall not disclose such Confidential Information and shall use
+ * it only in accordance with the terms of the license agreement
+ * you entered into with Constant Contact, Inc.
+ */
+
+package com.constantcontact.v2.converter.jackson;
+
+import com.constantcontact.v2.campaigns.Campaign;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import java.util.Date;
+import java.io.IOException;
+
+import okhttp3.RequestBody;
+import okio.Buffer;
+import retrofit2.Converter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ */
+public class JacksonTest {
+    private static final String ID = "123ABC";
+
+    private static final Date DATE = new Date(0);
+
+    private static final String CONTENT = "This is email content";
+
+    private static final String FROM_EMAIL = "null@dev.net";
+
+    private static final String FROM_NAME = "Me!";
+
+    private static final String NAME = "My Campaign";
+
+    private static final String REPLY_EMAIL = "null@dev.net";
+
+    private static final String TEXT_CONTENT = "This is text content";
+
+    private static final String SUBJECT = "READ ME";
+
+    private static final String ALL_EMOTICONS = "\uD83D\uDE0A\uD83D\uDE0A\uD83D\uDE0A";
+
+    private static final String DOUBLE_QUOTES = "\"Hello\"";
+
+    private static final String SINGLE_QUOTES = "\'\'";
+
+    private static final String EMOTICONS_AND_TEXT = "\uD83D\uDE0A\uD83D\uDE0A\uD83D\uDE0A Hello";
+
+    private static final String URL = "http://constantcontact.com";
+
+    private static final String PR_TEXT = "This is a reminder of permission";
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final JacksonConverterFactory factory = JacksonConverterFactory.create(objectMapper);
+
+    private static final Converter<Campaign, RequestBody> requestBodyConverter = (Converter<Campaign, RequestBody>)factory.requestBodyConverter(Campaign.class, null, null, null);
+
+    @Test
+    public void test_JacksonSerialization() throws IOException {
+        testTrimmedRequest(SUBJECT, SUBJECT);
+        // should weed out emoticons
+        testTrimmedRequest(ALL_EMOTICONS, "");
+        // should keep double quotes
+        testTrimmedRequest(DOUBLE_QUOTES, DOUBLE_QUOTES);
+        // should keep single quotes
+        testTrimmedRequest(SINGLE_QUOTES, SINGLE_QUOTES);
+        // emoticons and text
+        testTrimmedRequest(EMOTICONS_AND_TEXT, " Hello");
+    }
+
+    private void testTrimmedRequest(String subject, String subject_test) throws IOException {
+        Campaign campaign = new Campaign();
+        campaign.setEmailContent(CONTENT);
+        campaign.setFromEmail(FROM_EMAIL);
+        campaign.setFromName(FROM_NAME);
+        campaign.setName(NAME);
+        campaign.setPermissionReminderText(PR_TEXT);
+        campaign.setReplyToEmail(REPLY_EMAIL);
+        campaign.setTextContent(TEXT_CONTENT);
+        campaign.setSubject(subject);
+
+        //Convert the campaign into the body that gets passed to a request
+        RequestBody body = requestBodyConverter.convert(campaign);
+        Buffer buffer = new Buffer();
+        body.writeTo(buffer);
+        Campaign result = objectMapper.readValue(new String(buffer.readByteArray()), Campaign.class);
+        // test that the non-ascii characters were removed from the body of the request prior to sending
+        runAssertions(result, subject_test);
+    }
+
+
+    private void runAssertions(Campaign campaign, String subject) {
+        assertThat(campaign.getEmailContent(), is(CONTENT));
+        assertThat(campaign.getFromEmail(), is(FROM_EMAIL));
+        assertThat(campaign.getFromName(), is(FROM_NAME));
+        assertThat(campaign.getPermissionReminderText(), is(PR_TEXT));
+        assertThat(campaign.getName(), is(NAME));
+        assertThat(campaign.getReplyToEmail(), is(REPLY_EMAIL));
+        assertThat(campaign.getTextContent(), is(TEXT_CONTENT));
+        assertThat(campaign.getSubject(), is(subject));
+    }
+}

--- a/sdk-rx/src/test/java/com/constantcontact/v2/CCApiTest.java
+++ b/sdk-rx/src/test/java/com/constantcontact/v2/CCApiTest.java
@@ -1,0 +1,93 @@
+package com.constantcontact.v2;
+
+import com.constantcontact.v2.campaigns.Campaign;
+import com.constantcontact.v2.campaigns.SentToContactList;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import retrofit2.Response;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+import java.beans.PropertyDescriptor;
+import java.util.List;
+import java.util.UUID;
+
+public class CCApiTest {
+
+    private static final String EMOTICONS_STRING = "😉😉";
+    private static final String ALL_ASCII = "All Ascii";
+    private static final String SENT_TO = "1566174080";
+    private static final String EMAIL_CONTENT = "<!DOCTYPE HTML><html><body>nothing</body></html>";
+    private static final String EMAIL_ADDR = "maria.davila@endurance.com";
+    private static final String TEXT_CONTENT = "Hello there";
+    private static final String FROM_NAME = "Constant Contact";
+    private static final String apiKey = "mariKey";
+    private static final String token = "mariToken";
+    private static final CCApi2 ccapi = new CCApi2(apiKey, token);
+
+    //@Test
+    public void testEmoticons() throws Exception{
+
+        Campaign campaign = createCampaign();
+        // test emoticons in the subject string
+        setStringPropertyValue(campaign, "subject", EMOTICONS_STRING);
+        Campaign created = sendCampaign(campaign);
+        cleanupCampaign(created.getId());
+        // put the emoticons in textContent property. Clean up previous property
+        campaign = createCampaign();
+        setStringPropertyValue(campaign, "subject", ALL_ASCII);
+        setStringPropertyValue(campaign, "name", EMOTICONS_STRING + UUID.randomUUID().toString());
+        created = sendCampaign(campaign);
+        cleanupCampaign(created.getId());
+    }
+
+    private Campaign createCampaign() throws Exception{
+
+        Campaign campaign = new Campaign();
+        campaign.setName(UUID.randomUUID().toString());
+        campaign.setFromName(FROM_NAME);
+        SentToContactList sentTo = new SentToContactList();
+        sentTo.setId(SENT_TO);
+        campaign.setSentToContactLists(new SentToContactList[] {sentTo});
+        campaign.setSubject(EMOTICONS_STRING);
+        campaign.setEmailContent(EMAIL_CONTENT);
+        campaign.setReplyToEmail(EMAIL_ADDR);
+        campaign.setTextContent(TEXT_CONTENT);
+        campaign.setFromEmail(EMAIL_ADDR);
+        return campaign;
+    }
+
+    private void setStringPropertyValue(Campaign campaign, String attrName, String attrValue) throws Exception{
+        PropertyDescriptor descriptor = new PropertyDescriptor(attrName, Campaign.class);
+        descriptor.getWriteMethod().invoke(campaign, attrValue);
+    }
+
+    private void testStringPropertyValue(Campaign campaign, String attrName, String attrValue) throws Exception {
+        PropertyDescriptor descriptor = new PropertyDescriptor(attrName, Campaign.class);
+        assertEquals((String)descriptor.getReadMethod().invoke(campaign), attrValue);
+    }
+
+    private Campaign sendCampaign(Campaign campaign) {
+        Observable<Campaign> observable = ccapi.getCampaignService()
+                .createCampaign(campaign);
+        // synchronous subscriber, will wait until the observer calls onCompleted()
+        TestSubscriber<Campaign> testSubscriber = new TestSubscriber<>();
+        observable.subscribe(testSubscriber);
+        testSubscriber.assertNoErrors();
+        List<Campaign> created = testSubscriber.getOnNextEvents();
+        // return the campaign
+        return created.get(0);
+    }
+
+    private void cleanupCampaign(String id) {
+        Observable<Response<Void>> observable = ccapi.getCampaignService()
+                .deleteCampaign(id);
+        // synchronous subscriber, will wait until the observer calls onCompleted()
+        TestSubscriber<Response<Void>> testSubscriber = new TestSubscriber<>();
+        observable.subscribe(testSubscriber);
+        testSubscriber.assertNoErrors();
+    }
+
+}

--- a/sdk-rx/src/test/java/com/constantcontact/v2/CCApiTest.java
+++ b/sdk-rx/src/test/java/com/constantcontact/v2/CCApiTest.java
@@ -11,12 +11,16 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.beans.PropertyDescriptor;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class CCApiTest {
 
-    private static final String EMOTICONS_STRING = "😉😉";
+    private static final String EMOTICONS_STRING = "😉😉 Some Ascii";
+    private static final String CONTENT_WITH_EMOTICONS = "<!DOCTYPE HTML><html><body>nothing😉😉</body></html>";
+    // some default values to use when creating the campaign
     private static final String ALL_ASCII = "All Ascii";
     private static final String SENT_TO = "1566174080";
     private static final String EMAIL_CONTENT = "<!DOCTYPE HTML><html><body>nothing</body></html>";
@@ -27,20 +31,25 @@ public class CCApiTest {
     private static final String token = "mariToken";
     private static final CCApi2 ccapi = new CCApi2(apiKey, token);
 
+    private static Map<String,String> testPropertiesAndValues = new HashMap<>();
+
+    static {
+        // these two would have resulted in error before MOB-5549
+        testPropertiesAndValues.put("subject", EMOTICONS_STRING);
+        testPropertiesAndValues.put("name", EMOTICONS_STRING + UUID.randomUUID().toString());
+        // these were ok with emoticons before MOB-5549 and should still be ok
+        testPropertiesAndValues.put("emailContent", CONTENT_WITH_EMOTICONS);
+        testPropertiesAndValues.put("fromName", EMOTICONS_STRING);
+    }
     //@Test
     public void testEmoticons() throws Exception{
-
-        Campaign campaign = createCampaign();
-        // test emoticons in the subject string
-        setStringPropertyValue(campaign, "subject", EMOTICONS_STRING);
-        Campaign created = sendCampaign(campaign);
-        cleanupCampaign(created.getId());
-        // put the emoticons in textContent property. Clean up previous property
-        campaign = createCampaign();
-        setStringPropertyValue(campaign, "subject", ALL_ASCII);
-        setStringPropertyValue(campaign, "name", EMOTICONS_STRING + UUID.randomUUID().toString());
-        created = sendCampaign(campaign);
-        cleanupCampaign(created.getId());
+        for (Map.Entry entry : testPropertiesAndValues.entrySet()) {
+            Campaign campaign = createCampaign();
+            // test emoticons in the subject string
+            setStringPropertyValue(campaign, (String)entry.getKey(), (String)entry.getValue());
+            Campaign created = sendCampaign(campaign);
+            cleanupCampaign(created.getId());
+        }
     }
 
     private Campaign createCampaign() throws Exception{
@@ -51,7 +60,7 @@ public class CCApiTest {
         SentToContactList sentTo = new SentToContactList();
         sentTo.setId(SENT_TO);
         campaign.setSentToContactLists(new SentToContactList[] {sentTo});
-        campaign.setSubject(EMOTICONS_STRING);
+        campaign.setSubject(ALL_ASCII);
         campaign.setEmailContent(EMAIL_CONTENT);
         campaign.setReplyToEmail(EMAIL_ADDR);
         campaign.setTextContent(TEXT_CONTENT);


### PR DESCRIPTION
## PROBLEM
The problem as described in the jira entry is that using emoji in the subject field of a quick campaign causes an error banner that indicates that the campaign was not saved.

Upon inspection, if emoji are used in the subject line, the API for createCampaign returns a 500 server error. emoji in other String fields cause this error as well, for instance, name.

## SOLUTION
This problem was solved for the ios app by removing non ascii characters from the payload to the campaign creation service. A similar approach is taken for Android. I considered two possible ones:
- remove all non ascii from the full payload before the the service endpoint is called
- using @JsonSerialize annotation on the attributes of the campaign that we wish to make all ascii before the service call

I went with the second option which seemed more elegant, but the first one would probably work as well. The second one would entail checking each character of the full payload; the first one only intercepts the attributes that we mark with the annotation.

I also looked for a way to specify a built in filter for strings on the jackson serializer, but didn't find a hook to do that.
## TESTING
I create a unit test com.constantcontact.v2.converter.jackson.JacksonTest which verifies that non ascii (emoji are used) characters are removed from the subject. This test could be expanded to test all attributes we want to test

I create a roundtrip test that reproduced the error from the service call in com.constantcontact.v2.CCApiTest. The @Test is commented out and the api key and token are mocked up. I tried this test with my own api key and token, and it reproduced the error before the fix and ran smoothly after the fix. I need input on whether this kind of test is desirable. I would need to use a real api key and token. Do we have other tests that do this? Should I use generated keys and tokens for a test account?

## NOTES
The @JsonSerialize annotation has been added only to those attributes that are 1)Strings 2)passed thru to the CampaignService request 3) Are known to fail if they have emoticons in them. There are String Campaign attributes that are passed to the creation and update calls where emoticons are ok, for instance, emailContent and fromName
