### PR TITLE
MOB-5721 fix date pattern for QueryDate, hh --> HH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
 
     group = 'com.constantcontact'
     def isRelease = Boolean.valueOf(project.hasProperty("release") ? project.property("release") as String : "false")
-    version = '5.2.1' + (isRelease ? "" : "-SNAPSHOT")
+    version = '5.2.2' + (isRelease ? "" : "-SNAPSHOT")
 }
 
 apply plugin: "net.wooga.github"

--- a/components/src/main/java/com/constantcontact/v2/converter/jackson/JacksonConverterFactory.java
+++ b/components/src/main/java/com/constantcontact/v2/converter/jackson/JacksonConverterFactory.java
@@ -29,7 +29,7 @@ import java.util.SimpleTimeZone;
  * The converter factory used for Jackson JSON conversion
  */
 public class JacksonConverterFactory extends Converter.Factory {
-    public final static String ISO_8601_DATE_PATTERN = "yyyy-MM-dd'T'hh:mm:ss.SS'Z'";
+    public final static String ISO_8601_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SS'Z'";
 
     public final static SimpleDateFormat ISO_8601_DATE_FORMAT;
 

--- a/components/src/test/java/com/constantcontact/v2/QueryDateTests.java
+++ b/components/src/test/java/com/constantcontact/v2/QueryDateTests.java
@@ -12,8 +12,8 @@ public class QueryDateTests {
 
     @Test
     public void test24HourDateConversions() {
-        ZonedDateTime date = ZonedDateTime.parse("2018-06-04T09:07:30-04:00");
+        ZonedDateTime date = ZonedDateTime.parse("2018-06-04T09:07:30-04:00Z");
         QueryDate qd = new QueryDate(date.toInstant().toEpochMilli());
-        assertThat(qd.toString().indexOf("2018-06-04T13:07:30"), not(equalTo(-1)));
+        assertThat(qd.toString().indexOf("2018-06-04T13:07:30:00Z"), not(equalTo(-1)));
     }
 }

--- a/components/src/test/java/com/constantcontact/v2/QueryDateTests.java
+++ b/components/src/test/java/com/constantcontact/v2/QueryDateTests.java
@@ -12,8 +12,8 @@ public class QueryDateTests {
 
     @Test
     public void test24HourDateConversions() {
-        ZonedDateTime date = ZonedDateTime.parse("2018-06-04T09:07:30-04:00Z");
+        ZonedDateTime date = ZonedDateTime.parse("2018-06-04T09:07:30-04:00");
         QueryDate qd = new QueryDate(date.toInstant().toEpochMilli());
-        assertThat(qd.toString().indexOf("2018-06-04T13:07:30:00Z"), not(equalTo(-1)));
+        assertThat(qd.toString().indexOf("2018-06-04T13:07:30.00Z"), not(equalTo(-1)));
     }
 }

--- a/components/src/test/java/com/constantcontact/v2/QueryDateTests.java
+++ b/components/src/test/java/com/constantcontact/v2/QueryDateTests.java
@@ -1,0 +1,19 @@
+package com.constantcontact.v2;
+
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class QueryDateTests {
+
+    @Test
+    public void test24HourDateConversions() {
+        ZonedDateTime date = ZonedDateTime.parse("2018-06-04T09:07:30-04:00");
+        QueryDate qd = new QueryDate(date.toInstant().toEpochMilli());
+        assertThat(qd.toString().indexOf("2018-06-04T13:07:30"), not(equalTo(-1)));
+    }
+}


### PR DESCRIPTION
## PROBLEM
The date String pattern used by the QueryDate class did not support 24 hr time, and would produce incorrect date strings when used in service queries

## SOLUTION
Modified the string pattern  hours from hh to HH
## TESTING
A new unit test has been added to test that 24 hour time is supported in QueryDateTests.java
